### PR TITLE
fix(cli): scaffold @openmini/* deps from the CLI's own version (fixes broken ^0.0.0 pin)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Something in OpenMini doesn't work as documented
+labels: ["bug", "needs-triage"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of OpenMini is affected?
+      options:
+        - CLI (mini create/dev/build/pack/publish/inspect)
+        - Runtime (bridge client, mini.* SDK)
+        - React Native host SDK
+        - Registry protocol / publishing
+        - Specs
+        - Conformance suite
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what happened instead?
+      placeholder: |
+        1. Ran `mini create my-app`
+        2. Ran `npm install`
+        3. Got "No matching version found for ..."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Exact commands or a repo link. The faster we can reproduce, the faster it gets fixed.
+      render: shell
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: Output of `mini --version`, plus Node, package manager, and OS. For host issues, add React Native / Expo versions.
+      placeholder: |
+        @openmini/cli: 0.1.0
+        node: 22.x
+        pnpm: 9.x
+        macOS 15 / Android 15 / iOS 18
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Error output, stack traces, or bridge messages. Redact anything private.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/BoumouzounaBrahimVall/openmini/blob/main/SECURITY.md
+    about: Please do NOT open a public issue for vulnerabilities — follow the security policy instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Propose a new capability or improvement
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Heads up: the v0.1 bridge surface is frozen (6 built-in APIs + 3 host events
+        plus the `host.*` passthrough). Built-in additions are **spec changes first** —
+        see `specs/bridge-protocol.md`. Backlog items in `ROADMAP.md` are pull-gated:
+        describing your real-world need here is exactly the pull that un-gates them.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that OpenMini can't do today? Describe the use case, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work? CLI flags, API shape, spec change — whatever you have in mind.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, including the `host.*` passthrough for host-defined APIs.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI
+        - Runtime / bridge SDK
+        - React Native host SDK
+        - Registry protocol
+        - Specs
+        - New host adapter (Flutter, ...)
+        - Other
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+# What & why
+
+<!-- What does this PR change, and what problem does it solve?
+     Link the issue it fixes: Fixes #123 -->
+
+## How
+
+<!-- Anything a reviewer needs to know about the approach. -->
+
+## Checklist
+
+- [ ] `pnpm build` · `pnpm test` · `pnpm lint` · `pnpm format` all green
+- [ ] Tests cover the change (new behavior = new tests)
+- [ ] If this touches the bridge protocol, manifest, package format, or
+      registry protocol: the spec in `specs/` was updated **first**, and the
+      conformance suite (`conformance/`) still passes
+- [ ] Nothing in `packages/runtime`, `specs/`, or `conformance/` references a
+      specific host framework (RN, Flutter, ...)
+- [ ] No breaking change — or it's called out below and labeled `breaking-change`
+
+## Breaking changes
+
+<!-- Delete this section if none. -->

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -38,11 +38,6 @@ function cliVersion(): string {
   return OPENMINI_CLI_VERSION;
 }
 
-/** Unstamped dev builds (0.0.0) fall back to the latest published pair. */
-function sdkVersionRange(version: string): string {
-  return version === "0.0.0" ? "latest" : `^${version}`;
-}
-
 const program = new Command();
 
 program
@@ -63,7 +58,7 @@ program
       cwd: process.cwd(),
       templateDir,
       fs: nodeFs,
-      sdkVersionRange: sdkVersionRange(cliVersion()),
+      sdkVersion: cliVersion(),
     });
     process.stdout.write(
       `Created ${targetDir} (${files.length} files)\n\nNext:\n  cd ${name}\n  npm install\n  npx mini dev\n`,

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -19,12 +19,36 @@ import { fsRegistryTarget } from "./adapters/node/fs-registry.js";
 import { s3RegistryTarget } from "./adapters/s3/s3-registry.js";
 import { OPENMINI_CLI_VERSION } from "./index.js";
 
+/**
+ * The version release CI stamps into package.json from the git tag — the
+ * source constant stays 0.0.0 because builds happen before stamping.
+ */
+function cliVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(
+        fileURLToPath(new URL("../package.json", import.meta.url)),
+        "utf8",
+      ),
+    ) as { version?: string };
+    if (typeof pkg.version === "string") return pkg.version;
+  } catch {
+    // fall through
+  }
+  return OPENMINI_CLI_VERSION;
+}
+
+/** Unstamped dev builds (0.0.0) fall back to the latest published pair. */
+function sdkVersionRange(version: string): string {
+  return version === "0.0.0" ? "latest" : `^${version}`;
+}
+
 const program = new Command();
 
 program
   .name("mini")
   .description("OpenMini mini-app tooling")
-  .version(OPENMINI_CLI_VERSION);
+  .version(cliVersion());
 
 program
   .command("create")
@@ -39,6 +63,7 @@ program
       cwd: process.cwd(),
       templateDir,
       fs: nodeFs,
+      sdkVersionRange: sdkVersionRange(cliVersion()),
     });
     process.stdout.write(
       `Created ${targetDir} (${files.length} files)\n\nNext:\n  cd ${name}\n  npm install\n  npx mini dev\n`,

--- a/packages/cli/src/usecases/create-app.test.ts
+++ b/packages/cli/src/usecases/create-app.test.ts
@@ -27,6 +27,7 @@ function memoryFs(template: Record<string, string>) {
 
 const TEMPLATE = {
   "manifest.json": `{"manifestVersion":1,"id":"{{APP_ID}}","name":"{{APP_NAME}}","version":"0.1.0","runtimeVersion":">=0.0.0"}`,
+  "package.json": `{"dependencies":{"@openmini/runtime":"{{OPENMINI_VERSION_RANGE}}"},"devDependencies":{"@openmini/cli":"{{OPENMINI_VERSION_RANGE}}"}}`,
   "src/App.tsx": "export const name = '{{APP_NAME}}';",
   _gitignore: "node_modules/",
 };
@@ -41,7 +42,12 @@ describe("mini create", () => {
       fs,
     });
     expect(targetDir).toBe("/apps/my-todo");
-    expect(written).toEqual([".gitignore", "manifest.json", "src/App.tsx"]);
+    expect(written).toEqual([
+      ".gitignore",
+      "manifest.json",
+      "package.json",
+      "src/App.tsx",
+    ]);
     const manifest = parseManifest(
       files.get("/apps/my-todo/manifest.json") ?? "",
     );
@@ -51,6 +57,32 @@ describe("mini create", () => {
     });
     expect(files.get("/apps/my-todo/src/App.tsx")).toContain("my-todo");
     expect(files.has("/apps/my-todo/.gitignore")).toBe(true);
+  });
+
+  it("stamps @openmini/* deps with the given version range", () => {
+    const { fs, files } = memoryFs(TEMPLATE);
+    createApp({
+      name: "todo",
+      cwd: "/apps",
+      templateDir: "/tpl",
+      fs,
+      sdkVersionRange: "^0.1.0",
+    });
+    const pkg = JSON.parse(files.get("/apps/todo/package.json") ?? "") as {
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    expect(pkg.dependencies["@openmini/runtime"]).toBe("^0.1.0");
+    expect(pkg.devDependencies["@openmini/cli"]).toBe("^0.1.0");
+  });
+
+  it("defaults @openmini/* deps to the latest dist-tag", () => {
+    const { fs, files } = memoryFs(TEMPLATE);
+    createApp({ name: "todo", cwd: "/apps", templateDir: "/tpl", fs });
+    const pkg = JSON.parse(files.get("/apps/todo/package.json") ?? "") as {
+      dependencies: Record<string, string>;
+    };
+    expect(pkg.dependencies["@openmini/runtime"]).toBe("latest");
   });
 
   it("refuses bad names and existing targets", () => {

--- a/packages/cli/src/usecases/create-app.test.ts
+++ b/packages/cli/src/usecases/create-app.test.ts
@@ -59,14 +59,14 @@ describe("mini create", () => {
     expect(files.has("/apps/my-todo/.gitignore")).toBe(true);
   });
 
-  it("stamps @openmini/* deps with the given version range", () => {
+  it("stamps @openmini/* deps as ^<sdkVersion>", () => {
     const { fs, files } = memoryFs(TEMPLATE);
     createApp({
       name: "todo",
       cwd: "/apps",
       templateDir: "/tpl",
       fs,
-      sdkVersionRange: "^0.1.0",
+      sdkVersion: "0.1.0",
     });
     const pkg = JSON.parse(files.get("/apps/todo/package.json") ?? "") as {
       dependencies: Record<string, string>;
@@ -76,14 +76,23 @@ describe("mini create", () => {
     expect(pkg.devDependencies["@openmini/cli"]).toBe("^0.1.0");
   });
 
-  it("defaults @openmini/* deps to the latest dist-tag", () => {
-    const { fs, files } = memoryFs(TEMPLATE);
-    createApp({ name: "todo", cwd: "/apps", templateDir: "/tpl", fs });
-    const pkg = JSON.parse(files.get("/apps/todo/package.json") ?? "") as {
-      dependencies: Record<string, string>;
-    };
-    expect(pkg.dependencies["@openmini/runtime"]).toBe("latest");
-  });
+  it.each([undefined, "0.0.0", "0.0.0-dev.1"])(
+    "falls back to the latest dist-tag for unstamped builds (%s)",
+    (sdkVersion) => {
+      const { fs, files } = memoryFs(TEMPLATE);
+      createApp({
+        name: "todo",
+        cwd: "/apps",
+        templateDir: "/tpl",
+        fs,
+        sdkVersion,
+      });
+      const pkg = JSON.parse(files.get("/apps/todo/package.json") ?? "") as {
+        dependencies: Record<string, string>;
+      };
+      expect(pkg.dependencies["@openmini/runtime"]).toBe("latest");
+    },
+  );
 
   it("refuses bad names and existing targets", () => {
     const { fs } = memoryFs(TEMPLATE);

--- a/packages/cli/src/usecases/create-app.ts
+++ b/packages/cli/src/usecases/create-app.ts
@@ -20,11 +20,18 @@ export interface CreateAppOptions {
   templateDir: string;
   fs: FileSystemPort;
   /**
-   * Semver range or dist-tag stamped into the scaffold's `@openmini/*`
-   * dependencies. Defaults to `latest` so a scaffold always installs even
-   * when the CLI's own version is unknown (unstamped dev builds).
+   * The CLI's own version, stamped into the scaffold's `@openmini/*`
+   * dependencies as `^<version>`. Unstamped dev builds (0.0.0 or a
+   * 0.0.0-* prerelease) and omission fall back to the `latest` dist-tag
+   * so a scaffold always installs.
    */
-  sdkVersionRange?: string;
+  sdkVersion?: string;
+}
+
+function sdkVersionRange(sdkVersion: string | undefined): string {
+  if (sdkVersion === undefined || /^0\.0\.0(-|$)/.test(sdkVersion))
+    return "latest";
+  return `^${sdkVersion}`;
 }
 
 /** Scaffolds a plain React + Vite mini-app from the template directory. */
@@ -32,7 +39,7 @@ export function createApp(options: CreateAppOptions): {
   targetDir: string;
   files: string[];
 } {
-  const { name, cwd, templateDir, fs, sdkVersionRange = "latest" } = options;
+  const { name, cwd, templateDir, fs, sdkVersion } = options;
   if (!NAME_PATTERN.test(name)) {
     throw new CliError(
       `invalid app name "${name}" — use lowercase letters, digits, and dashes (e.g. "todo")`,
@@ -51,7 +58,7 @@ export function createApp(options: CreateAppOptions): {
       .readFile(fs.join(templateDir, relative))
       .replaceAll("{{APP_NAME}}", name)
       .replaceAll("{{APP_ID}}", appId)
-      .replaceAll("{{OPENMINI_VERSION_RANGE}}", sdkVersionRange);
+      .replaceAll("{{OPENMINI_VERSION_RANGE}}", sdkVersionRange(sdkVersion));
     // npm strips .gitignore from published packages; templates store it renamed.
     const target = relative === "_gitignore" ? ".gitignore" : relative;
     const path = fs.join(targetDir, target);

--- a/packages/cli/src/usecases/create-app.ts
+++ b/packages/cli/src/usecases/create-app.ts
@@ -19,6 +19,12 @@ export interface CreateAppOptions {
   cwd: string;
   templateDir: string;
   fs: FileSystemPort;
+  /**
+   * Semver range or dist-tag stamped into the scaffold's `@openmini/*`
+   * dependencies. Defaults to `latest` so a scaffold always installs even
+   * when the CLI's own version is unknown (unstamped dev builds).
+   */
+  sdkVersionRange?: string;
 }
 
 /** Scaffolds a plain React + Vite mini-app from the template directory. */
@@ -26,7 +32,7 @@ export function createApp(options: CreateAppOptions): {
   targetDir: string;
   files: string[];
 } {
-  const { name, cwd, templateDir, fs } = options;
+  const { name, cwd, templateDir, fs, sdkVersionRange = "latest" } = options;
   if (!NAME_PATTERN.test(name)) {
     throw new CliError(
       `invalid app name "${name}" — use lowercase letters, digits, and dashes (e.g. "todo")`,
@@ -44,7 +50,8 @@ export function createApp(options: CreateAppOptions): {
     const content = fs
       .readFile(fs.join(templateDir, relative))
       .replaceAll("{{APP_NAME}}", name)
-      .replaceAll("{{APP_ID}}", appId);
+      .replaceAll("{{APP_ID}}", appId)
+      .replaceAll("{{OPENMINI_VERSION_RANGE}}", sdkVersionRange);
     // npm strips .gitignore from published packages; templates store it renamed.
     const target = relative === "_gitignore" ? ".gitignore" : relative;
     const path = fs.join(targetDir, target);

--- a/packages/cli/templates/react/package.json
+++ b/packages/cli/templates/react/package.json
@@ -7,12 +7,12 @@
     "dev": "mini dev"
   },
   "dependencies": {
-    "@openmini/runtime": "^0.0.0",
+    "@openmini/runtime": "{{OPENMINI_VERSION_RANGE}}",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@openmini/cli": "^0.0.0",
+    "@openmini/cli": "{{OPENMINI_VERSION_RANGE}}",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "typescript": "^5.8.0"


### PR DESCRIPTION
# What & why

Fixes #1 — `mini create` scaffolded apps with `@openmini/runtime` and `@openmini/cli` pinned to `^0.0.0`, a version that was never published, so `npm install` in a fresh scaffold failed with "No matching version found".

## How

The template now uses a `{{OPENMINI_VERSION_RANGE}}` placeholder, and `mini create` stamps it at scaffold time:

- `bin.ts` reads the CLI's **own** `package.json` version (which release CI stamps from the git tag) and passes it to `createApp`, which stamps `^<version>`. This keeps runtime + cli in the same-version pair CI tested together — safer than a floating `latest`.
- Unstamped builds (`0.0.0` or any `0.0.0-*` prerelease) fall back to the `latest` dist-tag, so a scaffold always installs. The fallback decision lives in one place (the usecase) and is fully unit-tested.
- `mini --version` now reports the stamped version too, instead of the hardcoded `OPENMINI_CLI_VERSION = "0.0.0"` constant (the workflow builds before stamping, so the published binary lied).
- `createApp` gets an optional, backward-compatible `sdkVersion` option.

Second commit adds the repo's GitHub hygiene: bug-report and feature-request issue forms (auto-labeled `needs-triage`), a chooser config routing vulnerabilities to `SECURITY.md`, and a PR template whose checklist mirrors the working rules (verification gate, spec-first, host-framework independence).

Reviewed by the project code-reviewer agent; both MEDIUM findings (duplicated fallback knowledge, prerelease edge case) fixed in the third commit.

Verified end-to-end: scaffolded an app with the built CLI — deps stamp to `latest` in dev, and will stamp to `^<tag-version>` on published builds.

## Checklist

- [x] `pnpm build` · `pnpm test` (100/100) · `pnpm lint` · `pnpm format` all green
- [x] Tests cover the change (4 new cases in `create-app.test.ts`, incl. prerelease fallback)
- [x] No spec surface touched (CLI scaffolding only)
- [x] Nothing host-framework-specific added to runtime/specs/conformance
- [x] No breaking change (`sdkVersion` is optional; `OPENMINI_CLI_VERSION` export unchanged)