### PR TITLE
fix(cli): tolerate whitespace in scaffold placeholders; generate release notes in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: read
+  contents: write # create the GitHub Release for the tag
   id-token: write # npm provenance attestation
 
 concurrency:
@@ -49,3 +49,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+      - name: Create GitHub Release with generated notes
+        run: gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/packages/cli/src/usecases/create-app.test.ts
+++ b/packages/cli/src/usecases/create-app.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { nodeFs } from "../adapters/node/node-fs.js";
 import { parseManifest } from "./validate-manifest.js";
 import { createApp, type FileSystemPort } from "./create-app.js";
 
@@ -94,6 +98,15 @@ describe("mini create", () => {
     },
   );
 
+  it("replaces placeholders written with inner whitespace", () => {
+    const { fs, files } = memoryFs({
+      ...TEMPLATE,
+      "src/App.tsx": "<h1>{{ APP_NAME }}</h1>",
+    });
+    createApp({ name: "my-todo", cwd: "/apps", templateDir: "/tpl", fs });
+    expect(files.get("/apps/my-todo/src/App.tsx")).toBe("<h1>my-todo</h1>");
+  });
+
   it("refuses bad names and existing targets", () => {
     const { fs } = memoryFs(TEMPLATE);
     expect(() =>
@@ -103,5 +116,31 @@ describe("mini create", () => {
     expect(() =>
       createApp({ name: "todo", cwd: "/apps", templateDir: "/tpl", fs }),
     ).toThrow(/already exists/);
+  });
+});
+
+describe("mini create (real react template)", () => {
+  const cwd = mkdtempSync(nodeFs.join(tmpdir(), "openmini-create-"));
+  afterEach(() => rmSync(cwd, { recursive: true, force: true }));
+
+  it("scaffolds with no unreplaced {{ … }} placeholders", () => {
+    const templateDir = fileURLToPath(
+      new URL("../../templates/react", import.meta.url),
+    );
+    const { targetDir, files } = createApp({
+      name: "demo",
+      cwd,
+      templateDir,
+      fs: nodeFs,
+    });
+    for (const file of files) {
+      const content = nodeFs.readFile(nodeFs.join(targetDir, file));
+      expect(content, `${file} has an unreplaced placeholder`).not.toMatch(
+        /\{\{[^}]*\}\}/,
+      );
+    }
+    expect(nodeFs.readFile(nodeFs.join(targetDir, "src/App.tsx"))).toContain(
+      "<h1>demo</h1>",
+    );
   });
 });

--- a/packages/cli/src/usecases/create-app.ts
+++ b/packages/cli/src/usecases/create-app.ts
@@ -54,11 +54,16 @@ export function createApp(options: CreateAppOptions): {
   const appId = `com.example.${name.replaceAll("-", "")}`;
   const written: string[] = [];
   for (const relative of fs.listFiles(templateDir)) {
+    // Tolerate inner whitespace ({{ APP_NAME }}) so a reformatted template
+    // can't ship an unreplaced placeholder into the scaffold.
     const content = fs
       .readFile(fs.join(templateDir, relative))
-      .replaceAll("{{APP_NAME}}", name)
-      .replaceAll("{{APP_ID}}", appId)
-      .replaceAll("{{OPENMINI_VERSION_RANGE}}", sdkVersionRange(sdkVersion));
+      .replaceAll(/\{\{\s*APP_NAME\s*\}\}/g, name)
+      .replaceAll(/\{\{\s*APP_ID\s*\}\}/g, appId)
+      .replaceAll(
+        /\{\{\s*OPENMINI_VERSION_RANGE\s*\}\}/g,
+        sdkVersionRange(sdkVersion),
+      );
     // npm strips .gitignore from published packages; templates store it renamed.
     const target = relative === "_gitignore" ? ".gitignore" : relative;
     const path = fs.join(targetDir, target);


### PR DESCRIPTION
# What & why

`mini create` scaffolds an `App.tsx` that fails to compile: it still contains the literal `{{ APP_NAME }}` placeholder, which JSX parses as an object-literal shorthand for an undefined `APP_NAME` binding. Fixes #3.

Also adds a GitHub Release step with `--generate-notes` to the release workflow, so every published `v*` tag gets auto-generated release notes.

## How

**The bug's actual root cause:** Prettier formats the react template's JSX and rewrites `{{APP_NAME}}` to `{{ APP_NAME }}` (spaces inside JSX expression braces) — verified locally: `pnpm format` reintroduces the spaced form immediately. The scaffolder's exact-match `replaceAll("{{APP_NAME}}", …)` then misses it.

So instead of "fixing" the template (which the formatter would undo on the next `pnpm format`), the substitution in `create-app.ts` now uses whitespace-tolerant regexes (`/\{\{\s*APP_NAME\s*\}\}/g`, same for `APP_ID` and `OPENMINI_VERSION_RANGE`).

Tests (written first, confirmed red on `main`):
- unit: a `{{ APP_NAME }}` placeholder with inner spaces is replaced;
- regression: scaffold from the **real** `templates/react` directory via the real `nodeFs` adapter and assert no `{{ … }}` token survives in any written file — this is the coverage gap that let the bug ship (the existing test used only an inline in-memory template).

**Release CI:** after the npm publish step, `gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes` creates the GitHub Release; `permissions.contents` is raised from `read` to `write` (required to create a Release; `id-token: write` for provenance is unchanged).

## Checklist

- [x] `pnpm build` · `pnpm test` · `pnpm lint` · `pnpm format` all green (102/102 tests)
- [x] Tests cover the change (new behavior = new tests)
- [x] If this touches the bridge protocol, manifest, package format, or
      registry protocol: the spec in `specs/` was updated **first**, and the
      conformance suite (`conformance/`) still passes — N/A, no protocol surface touched
- [x] Nothing in `packages/runtime`, `specs/`, or `conformance/` references a
      specific host framework (RN, Flutter, ...)
- [x] No breaking change — or it's called out below and labeled `breaking-change`
