### PR TITLE
feat(cli): scaffold an AGENTS.md with agent guidance and version-pinned docs links

### DIFF
--- a/packages/cli/src/usecases/create-app.test.ts
+++ b/packages/cli/src/usecases/create-app.test.ts
@@ -33,6 +33,8 @@ const TEMPLATE = {
   "manifest.json": `{"manifestVersion":1,"id":"{{APP_ID}}","name":"{{APP_NAME}}","version":"0.1.0","runtimeVersion":">=0.0.0"}`,
   "package.json": `{"dependencies":{"@openmini/runtime":"{{OPENMINI_VERSION_RANGE}}"},"devDependencies":{"@openmini/cli":"{{OPENMINI_VERSION_RANGE}}"}}`,
   "src/App.tsx": "export const name = '{{APP_NAME}}';",
+  "AGENTS.md":
+    "Docs: https://example.com/repo/blob/{{OPENMINI_DOCS_REF}}/specs/bridge-protocol.md",
   _gitignore: "node_modules/",
 };
 
@@ -48,6 +50,7 @@ describe("mini create", () => {
     expect(targetDir).toBe("/apps/my-todo");
     expect(written).toEqual([
       ".gitignore",
+      "AGENTS.md",
       "manifest.json",
       "package.json",
       "src/App.tsx",
@@ -80,6 +83,18 @@ describe("mini create", () => {
     expect(pkg.devDependencies["@openmini/cli"]).toBe("^0.1.0");
   });
 
+  it("pins docs links to the v<sdkVersion> tag for stamped builds", () => {
+    const { fs, files } = memoryFs(TEMPLATE);
+    createApp({
+      name: "todo",
+      cwd: "/apps",
+      templateDir: "/tpl",
+      fs,
+      sdkVersion: "0.1.0",
+    });
+    expect(files.get("/apps/todo/AGENTS.md")).toContain("/blob/v0.1.0/");
+  });
+
   it.each([undefined, "0.0.0", "0.0.0-dev.1"])(
     "falls back to the latest dist-tag for unstamped builds (%s)",
     (sdkVersion) => {
@@ -95,6 +110,7 @@ describe("mini create", () => {
         dependencies: Record<string, string>;
       };
       expect(pkg.dependencies["@openmini/runtime"]).toBe("latest");
+      expect(files.get("/apps/todo/AGENTS.md")).toContain("/blob/main/");
     },
   );
 
@@ -142,5 +158,6 @@ describe("mini create (real react template)", () => {
     expect(nodeFs.readFile(nodeFs.join(targetDir, "src/App.tsx"))).toContain(
       "<h1>demo</h1>",
     );
+    expect(files).toContain("AGENTS.md");
   });
 });

--- a/packages/cli/src/usecases/create-app.ts
+++ b/packages/cli/src/usecases/create-app.ts
@@ -34,6 +34,17 @@ function sdkVersionRange(sdkVersion: string | undefined): string {
   return `^${sdkVersion}`;
 }
 
+/**
+ * Git ref the scaffold's docs links point at (AGENTS.md), so agents read the
+ * specs matching the installed SDK, not whatever is on main. Unstamped dev
+ * builds fall back to main.
+ */
+function docsRef(sdkVersion: string | undefined): string {
+  if (sdkVersion === undefined || /^0\.0\.0(-|$)/.test(sdkVersion))
+    return "main";
+  return `v${sdkVersion}`;
+}
+
 /** Scaffolds a plain React + Vite mini-app from the template directory. */
 export function createApp(options: CreateAppOptions): {
   targetDir: string;
@@ -63,7 +74,8 @@ export function createApp(options: CreateAppOptions): {
       .replaceAll(
         /\{\{\s*OPENMINI_VERSION_RANGE\s*\}\}/g,
         sdkVersionRange(sdkVersion),
-      );
+      )
+      .replaceAll(/\{\{\s*OPENMINI_DOCS_REF\s*\}\}/g, docsRef(sdkVersion));
     // npm strips .gitignore from published packages; templates store it renamed.
     const target = relative === "_gitignore" ? ".gitignore" : relative;
     const path = fs.join(targetDir, target);

--- a/packages/cli/templates/react/AGENTS.md
+++ b/packages/cli/templates/react/AGENTS.md
@@ -1,0 +1,74 @@
+# {{APP_NAME}} — OpenMini mini-app
+
+Instructions for AI coding agents (and humans) working in this project.
+
+## What this is
+
+An OpenMini mini-app: a plain React web app that talks to its host app
+through the typed `mini.*` bridge from `@openmini/runtime`. It builds to
+static files, is packaged as a `.mpkg`, and is distributed via a
+static-file registry. There is no server code here, and no host-framework
+code (React Native, Flutter, …) — the host is opaque behind `mini.*`.
+
+## Check up-to-date docs before trusting memory
+
+OpenMini is young and moves fast. Do NOT rely on trained-in knowledge of
+its APIs — fetch the specs pinned to the SDK version this app was
+scaffolded with before adding or changing any `mini.*` call, manifest
+field, or packaging step:
+
+- Bridge protocol (API surface, errors, events):
+  https://github.com/BoumouzounaBrahimVall/openmini/blob/{{OPENMINI_DOCS_REF}}/specs/bridge-protocol.md
+- Manifest:
+  https://github.com/BoumouzounaBrahimVall/openmini/blob/{{OPENMINI_DOCS_REF}}/specs/manifest.md
+- Package format (`.mpkg`):
+  https://github.com/BoumouzounaBrahimVall/openmini/blob/{{OPENMINI_DOCS_REF}}/specs/package-format.md
+- Registry protocol (publishing):
+  https://github.com/BoumouzounaBrahimVall/openmini/blob/{{OPENMINI_DOCS_REF}}/specs/registry-protocol.md
+- Latest docs (may be newer than this app's SDK):
+  https://github.com/BoumouzounaBrahimVall/openmini#readme
+
+## Commands
+
+- `npx mini dev` (or `npm run dev`) — dev server with a browser mock host
+- `npx mini build` — production-build to `dist/web`
+- `npx mini pack` — build and package into `dist/<id>-<version>.mpkg`
+- `npx mini inspect <file.mpkg>` — validate a package and print its summary
+- `npx mini publish [package] --registry <dir | s3://bucket[/prefix]>` —
+  publish to a registry
+
+## Bridge surface (v1 — FROZEN)
+
+The built-in surface is frozen: do NOT invent `mini.*` APIs. Anything not
+listed here must go through host-defined APIs (`mini.host.*`) or an
+upstream spec change.
+
+| API                                                   | Manifest permission |
+| ----------------------------------------------------- | ------------------- |
+| `mini.storage.get/set/remove` — string KV, per-app    | `storage`           |
+| `mini.ui.showToast({ message, durationMs? })`         | `toast`             |
+| `mini.system.getInfo()` — platform, locale, theme, …  | —                   |
+| `mini.navigation.close()` — ask host to dismiss app   | —                   |
+| `mini.request({ url, method?, headers?, body?, … })`  | `network`           |
+| `mini.host.invoke(name, payload?)` / `.on(name, cb)`  | `host:<name>`       |
+| `mini.lifecycle.onLaunch/onShow/onHide/onDestroy(cb)` | —                   |
+
+Failures reject with a `BridgeError` whose `code` is one of
+`PERMISSION_DENIED`, `API_NOT_FOUND`, `INVALID_PAYLOAD`,
+`NETWORK_DOMAIN_BLOCKED`, `HOST_ERROR`, `TIMEOUT`.
+
+## Manifest (`manifest.json`)
+
+The manifest gates the bridge: a permissioned API only works if listed in
+`permissions`, and `mini.request` origins must be in `allowedDomains`
+(checked before any I/O). This app's id is `{{APP_ID}}`. Full field rules
+are in the manifest spec above.
+
+## Rules of thumb
+
+- Storage keys and values are strings — JSON-encode structured data.
+- Non-2xx HTTP responses resolve normally; check `response.status`
+  (HTTP errors are data, not bridge errors).
+- `mini.lifecycle.onDestroy` is the last message the app receives — flush
+  state there.
+- Any React UI library is fine; the bridge doesn't care about rendering.


### PR DESCRIPTION
# What & why

`mini create` now scaffolds an `AGENTS.md` so AI coding agents dropped into a fresh mini-app know what they're working with — and, most importantly, where the **up-to-date** docs live instead of answering from stale training data. Closes #5.

## How

The scaffolded `AGENTS.md` (content verified against the actual code/specs, not from memory) covers:

- orientation: what an OpenMini mini-app is (plain React + `mini.*` bridge, `.mpkg`, static-file registry), host-framework independent;
- the CLI workflow (`mini dev/build/pack/inspect/publish` with their real flags/outputs from `bin.ts`);
- the **frozen** v1 bridge surface as a table of `mini.*` calls with their manifest permissions, the `BridgeError` codes from bridge-protocol §4, and an explicit "do not invent `mini.*` APIs — use `mini.host.*` or an upstream spec change" warning;
- manifest gating rules (`permissions`, `allowedDomains`);
- **version-pinned docs links**: a new `{{OPENMINI_DOCS_REF}}` placeholder resolves to the `v<version>` git tag matching the CLI's own stamped version (`main` for unstamped dev builds), so spec URLs like `…/blob/v0.1.0/specs/bridge-protocol.md` match the SDK the scaffold actually installs. Agents are told to fetch these before trusting remembered API shapes.

`create-app.ts` grows a `docsRef()` helper (mirroring the existing `sdkVersionRange()` fallback rules) and one more whitespace-tolerant `replaceAll`.

Tests (written first, red before implementation): docs ref stamps `v0.1.0` for stamped builds, falls back to `main` for unstamped ones, and the real-template regression test now asserts `AGENTS.md` is scaffolded with no unreplaced placeholders.

## Checklist

- [x] `pnpm build` · `pnpm test` · `pnpm lint` · `pnpm format` all green (103/103 tests)
- [x] Tests cover the change (new behavior = new tests)
- [x] If this touches the bridge protocol, manifest, package format, or
      registry protocol: the spec in `specs/` was updated **first**, and the
      conformance suite (`conformance/`) still passes — N/A, docs-only template content; no protocol change
- [x] Nothing in `packages/runtime`, `specs/`, or `conformance/` references a
      specific host framework (RN, Flutter, ...) — AGENTS.md lives in the CLI template and names host frameworks only to say the mini-app must not import them
- [x] No breaking change — or it's called out below and labeled `breaking-change`
