### PR TITLE
docs: contributor guidelines, code of conduct, and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything: review is auto-requested on every PR.
+* @BoumouzounaBrahimVall

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer, [@BoumouzounaBrahimVall](https://github.com/BoumouzounaBrahimVall),
+via a direct message on GitHub or, for sensitive reports, through this
+repository's private reporting channel (Security tab → "Report a
+vulnerability", marked as a conduct report).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to OpenMini
+
+Thanks for helping build the open mini-app runtime. This guide is short;
+the [PR template](.github/PULL_REQUEST_TEMPLATE.md) and CI enforce most of
+it mechanically.
+
+## The invariants (read first)
+
+These are the rules that make OpenMini what it is — PRs that break them
+won't merge:
+
+- **Specs are the source of truth.** Any change to the bridge protocol,
+  manifest, package format, or registry protocol updates the spec in
+  [`specs/`](specs/) **before** the code, and the conformance suite
+  ([`conformance/`](conformance/)) must still pass.
+- **The v0.1 bridge surface is frozen** (6 built-in APIs + 3 host events +
+  the `host.*` passthrough). New built-ins are spec changes first — open an
+  issue before writing code.
+- **Host-framework independence.** Nothing in `packages/runtime`, `specs/`,
+  or `conformance/` may reference React Native, Flutter, or any host.
+  React Native is just the first host adapter.
+- **Hexagonal architecture is law** — dependencies point inward, side
+  effects behind ports, one composition root per package. See
+  [`specs/architecture.md`](specs/architecture.md).
+
+## Dev setup
+
+Node 22 and [pnpm](https://pnpm.io). Then:
+
+```bash
+pnpm install
+pnpm build    # tsc across all packages
+pnpm test     # vitest, repo-wide (includes the conformance suite)
+pnpm lint     # eslint
+pnpm format   # prettier --write
+```
+
+## Workflow
+
+1. Open or pick an issue (use the issue forms). Roadmap items in
+   [`ROADMAP.md`](ROADMAP.md) are pull-gated — describing your real-world
+   need is exactly the pull that un-gates them.
+2. Fork/branch — `main` is protected; all changes land via pull request
+   with green CI (`verify` runs build, tests, lint, and format check).
+3. Tests come with the change: new behavior means new tests, bug fixes
+   start with a failing regression test.
+4. Use [Conventional Commits](https://www.conventionalcommits.org):
+   `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci` —
+   e.g. `fix(cli): tolerate whitespace inside scaffold placeholders`.
+5. Fill in the PR template checklist; link the issue (`Fixes #123`).
+
+Keep PRs to one logical change. Small and reviewable beats big and clever.
+
+## Reporting
+
+- **Bugs / feature requests** — the
+  [issue forms](https://github.com/BoumouzounaBrahimVall/openmini/issues/new/choose).
+- **Security issues** — never in a public issue; see [SECURITY.md](SECURITY.md)
+  for private vulnerability reporting.
+
+## Code of conduct
+
+Participation is covered by the [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
# What & why

Adds the missing community-standards files so contributors have written rules, complementing the `protect-main` ruleset hardening (PR required + green `verify` check) applied in repo settings:

- **`CONTRIBUTING.md`** — leads with the project invariants (specs are source of truth, frozen v0.1 bridge surface, host-framework independence, hexagonal architecture), then dev setup, PR workflow with Conventional Commits, and reporting channels (issue forms, SECURITY.md).
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1, maintainer as enforcement contact.
- **`.github/CODEOWNERS`** — `* @BoumouzounaBrahimVall`, auto-requests maintainer review on every PR.

## How

Docs only — no code, no protocol surface. GitHub picks all three up automatically (contributing link on first-time PRs/issues, community-standards checklist, review auto-request).

## Checklist

- [x] `pnpm build` · `pnpm test` · `pnpm lint` · `pnpm format` all green
- [x] Tests cover the change (new behavior = new tests) — N/A, docs only
- [x] If this touches the bridge protocol, manifest, package format, or
      registry protocol: the spec in `specs/` was updated **first**, and the
      conformance suite (`conformance/`) still passes — N/A
- [x] Nothing in `packages/runtime`, `specs/`, or `conformance/` references a
      specific host framework (RN, Flutter, ...)
- [x] No breaking change — or it's called out below and labeled `breaking-change`
