### PR TITLE
fix(deps): pin uuid 11.1.1 in playground-expo to clear GHSA-w5hq-g745-h8pq

### DIFF
--- a/apps/playground-expo/package-lock.json
+++ b/apps/playground-expo/package-lock.json
@@ -33,12 +33,12 @@
       "devDependencies": {
         "@openmini/cli": "workspace:*",
         "@openmini/conformance": "workspace:*",
-        "@react-native-async-storage/async-storage": "^2.2.0",
-        "@types/node": "^22.10.0",
-        "@types/react": "^19.1.0",
-        "react": "^19.1.0",
-        "react-native": "^0.86.0",
-        "typescript": "^5.8.0"
+        "@react-native-async-storage/async-storage": "^3.1.1",
+        "@types/node": "^26.2.0",
+        "@types/react": "^19.2.18",
+        "react": "^19.2.8",
+        "react-native": "^0.86.2",
+        "typescript": "^6.0.3"
       },
       "peerDependencies": {
         "@react-native-async-storage/async-storage": ">=1.19",
@@ -5833,13 +5833,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/apps/playground-expo/package.json
+++ b/apps/playground-expo/package.json
@@ -19,7 +19,8 @@
     "js-yaml": "4.3.1",
     "nanoid": "3.3.18",
     "postcss": "8.5.26",
-    "brace-expansion": "5.0.9"
+    "brace-expansion": "5.0.9",
+    "uuid": "11.1.1"
   },
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
Closes Dependabot alert **#1** — `uuid` < 11.1.1, GHSA-w5hq-g745-h8pq (moderate):
missing buffer bounds check in `v3`/`v5`/`v6` when a `buf` argument is supplied.

### Where it comes from

```
apps/playground-expo
└─ xcode@3.0.1  (uuid: ^7.0.3)   ← used by `expo prebuild` to generate the iOS project
   └─ uuid@7.0.3
```

There is no 7.x backport — the advisory's only patched versions are 11.1.1 / 12.0.1 / 13.0.1 —
so the fix has to be an `overrides` pin. That is already the established pattern in this
manifest (`js-yaml`, `nanoid`, `postcss`, `brace-expansion`), added in fe9d915.

### Why it is not a breaking change

`xcode` touches `uuid` in exactly one place:

```js
// node_modules/xcode/lib/pbxProject.js
uuid = require('uuid'),
...
var id = uuid.v4()
```

uuid 11 is dual CJS/ESM and still exports `v4` as a named export, so `require('uuid').v4()`
resolves. Verified against the real `apps/playground-expo/ios/playgroundexpo.xcodeproj`:

```
uuid resolved: 11.1.1
xcode.generateUuid() -> 328BF87871634536A943B672 OK (24-char pbx uuid)
first target: playgroundexpo
writeSync() bytes: 25517 OK
```

`npm audit` in `apps/playground-expo` no longer reports `uuid`.

Because this PR touches `apps/playground-expo/**`, the Expo workflow runs both native jobs —
so `expo prebuild` (the actual consumer of `xcode`) is exercised on iOS and Android in CI.

Only `package.json` + `package-lock.json` change; no source changes.
