### PR TITLE
fix(release): ship src so the published sourcemaps resolve

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,8 @@
   },
   "files": [
     "dist",
+    "src",
+    "!src/**/*.test.ts",
     "templates"
   ],
   "scripts": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -18,6 +18,8 @@
   },
   "files": [
     "dist",
+    "src",
+    "!src/**/*.test.ts",
     "android",
     "ios",
     "OpenminiReactNative.podspec",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,7 +13,9 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src",
+    "!src/**/*.test.ts"
   ],
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
Closes #37.

Takes **option 1** from the issue — ship the sources — rather than deleting the maps.

### Why this option

The two options cost about the same in bytes: shipping `src` adds roughly what the maps already
weigh. So the decision isn't size, it's whether the maps are worth having at all. For a bridge SDK
they are: stack traces cross OpenMini code on every `mini.*` call and every host dispatch, and a
resolvable map turns an opaque `dist` frame into `bridge-host.ts:142`. `declarationMap` + `src` also
makes "go to definition" land on real annotated TypeScript instead of a `.d.ts` — which is the point
of a typed bridge.

Option 3 (declaration maps only) still needs `src`, so it pays the same source bytes and gives up
runtime stack traces to save half the map bytes. Option 2 (delete the maps) is right only if tarball
size is the binding constraint, and at 50 kB it isn't.

### The change

One `files` entry per package, minus the tests:

```diff
-  "files": ["dist"]
+  "files": ["dist", "src", "!src/**/*.test.ts"]
```

The exclusion mirrors each package's tsconfig `exclude` exactly — all three are
`["src/**/*.test.ts"]`, and all 24 test files in the repo are `.test.ts` — so what the compiler
keeps out of `dist` is what the tarball keeps out. No test file ships, and no map references one.

No build-config change and no `prepack` script.

### Verification

**Every map now resolves.** Packed all three and checked each `sources` entry against the tarball's
own file list:

| Tarball | maps | sources checked | unresolved | `src/` shipped | tests shipped |
|---|---|---|---|---|---|
| `openmini-runtime` | 18 | 18 | **0** | 9 | 0 |
| `openmini-cli` | 42 | 42 | **0** | 21 | 0 |
| `openmini-react-native` | 60 | 60 | **0** | 30 | 0 |

Before this change every one of those 120 entries pointed at a missing file.

**No new public API surface.** All three packages have a closed `exports` map, so deep imports stay
blocked regardless of tarball contents. Installed the packed tarball into a scratch consumer to
confirm rather than assume:

```
@openmini/runtime                -> RESOLVED
@openmini/runtime/src/index.ts   -> blocked  ERR_PACKAGE_PATH_NOT_EXPORTED
@openmini/runtime/dist/index.js  -> blocked  ERR_PACKAGE_PATH_NOT_EXPORTED
```

**Size cost** (packed): runtime 16.1 → 19.3 kB · cli 36.9 → 48.8 kB · react-native 167.2 → 180.4 kB.

**Repo green:** build ✅ · 25 files / 103 tests ✅ · lint ✅ · format ✅.

### Note

No source or API change — only `files` metadata — so this doesn't require a release on its own. It
takes effect on the next tag, and #37's acceptance check (unpack a `--dry-run` publish and confirm
no map has absent sources) now passes.
